### PR TITLE
Minor improvement to MIME debugging output

### DIFF
--- a/pso
+++ b/pso
@@ -41,7 +41,7 @@ try_mime(){
             if [ "$debug" -eq 0 ]; then
                 exec_cmd "$cmd" "$resource"
             fi
-            [ "$debug" -eq 1 ] && echo "[*] mime: $mime cmd: $cmd (from $1)"
+            [ "$debug" -eq 1 ] && echo "[*] cmd: $cmd (from $1)"
         fi
     done <<EOF
 $config
@@ -100,8 +100,9 @@ echo "$resource" | grep -E "^file://" > /dev/null
 if [ -d "$resource" ]; then
     exec_cmd "$PSO_FOLDER_CMD" "$resource"
 elif [ -f "$resource" ]; then
-    resource_mime=$(file -b --mime-type "$resource")
     try_regex "$PSO_REGEX_CONFIG"
+    resource_mime=$(file -b --mime-type "$resource")
+    [ "$debug" -eq 1 ] && echo "[*] mime: $resource_mime"
     try_mime "$PSO_MIME_CONFIG"
     ask
 else


### PR DESCRIPTION
Hello,

This PR just moves around a bit of the debugging output. The mime type is only checked after `try_regex` (since it's not needed if `try_regex` matches anything).

I also made it so that the mime type is output immediately after try_regex fails, since this is useful debugging output--if the MIME type is output, we know that `pso` didn't find any matching regex. Additionally, if no MIME type matches, we are automatically informed of what type the file is (it might not be what we're expecting).

P.S. Thank you for creating and sharing this script! The default `xdg-open` is horrendous, as you're aware.