### PR TITLE
Use regex to match against MIME types

### DIFF
--- a/pso
+++ b/pso
@@ -37,7 +37,7 @@ EOF
 try_mime(){
     config=$(grep "^[^#]" "$1")
     while IFS=: read -r cmd mime; do
-        if [ "$mime" = "$resource_mime" ]; then
+        if echo "$resource_mime" | grep -E "^$mime\$" > /dev/null ; then
             if [ "$debug" -eq 0 ]; then
                 exec_cmd "$cmd" "$resource"
             fi


### PR DESCRIPTION
Hello again,

This is another minor change. This changes MIME type checking to use `grep -E` instead of simple string equality. Since MIME types don't have any special characters, this won't affect MIME types as specified normally. The improvement it provides is that now you can specify entire classes of MIME types, i.e. you can just use `text/.*` instead of having to specify `text/plain`, `text/x-shellscript`, `text/x-python`, etc.

Normally MIME globs are specified like `text/*` (i.e. in browser `Accept` headers in HTTP requests) but I figured it would be simpler to just use `grep -E` again. Not sure if you think the behavior should be glob-style or if this approach is fine.