### PR TITLE
bugfix: don't actually open the directory if -d is passed.

### DIFF
--- a/pso
+++ b/pso
@@ -94,7 +94,11 @@ echo "$resource" | grep -E "^file://" > /dev/null
 [ $? -eq 0 ] && resource=$(echo "$resource" | sed 's#^file://##;s/+/ /g;s/%\(..\)/\\x\1/g;' | xargs -0 printf "%b")
 
 if [ -d "$resource" ]; then
-    exec_cmd "$PSO_FOLDER_CMD" "$resource"
+    if [ "$debug" -eq 1 ]; then
+        echo "[*] directory; cmd: $PSO_FOLDER_CMD"
+    else
+        exec_cmd "$PSO_FOLDER_CMD" "$resource"
+    fi
 elif [ -f "$resource" ]; then
     resource_mime=$(file -b --mime-type "$resource")
     try_regex "$PSO_REGEX_CONFIG"


### PR DESCRIPTION
One last PR for now!

Currently, `pso` will always run `$PSO_FOLDER_CMD` when called on a directory, even if debug mode is on. This fixes that.